### PR TITLE
fix: update pnpm version in ci to fix broken ci

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -19,7 +19,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm test
+npx --no -- jest


### PR DESCRIPTION
#### What does this PR do?

* bump pnpm version in ci to 8 to fix the broken pipeline
*  update the pre-push test script